### PR TITLE
Compile sdists to flit core backend

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -43,8 +43,9 @@ class Layout(abc.ABC):
         should be included or filtered. Return None if the object should
         be omitted. Otherwise, relocate the object to self.prefix.
         """
+        info.name = info.name.removeprefix('./')
         ignore_pattern = '|'.join(self.ignored)
-        if info.name != '.' and re.match(ignore_pattern, info.name.removeprefix('./')):
+        if info.name != '.' and re.match(ignore_pattern, info.name):
             return
         info.name = str(pathlib.PurePosixPath(self.prefix(info.name), info.name))
         return info

--- a/backend.py
+++ b/backend.py
@@ -99,9 +99,12 @@ class FlitSDist(SDist):
     namespace(name='foo-1.0/README.md')
     """
 
+    ignored = SDist.ignored + [re.escape('pyproject.toml')]
+
     def prefix(self, name):
         package = self.metadata['Name'].replace('.', '/')
-        if name.startswith('README.md'):
+        root_pattern = '|'.join(Wheel.ignored)
+        if re.match(root_pattern, name):
             return pathlib.PurePath(self.metadata.id)
         return pathlib.PurePath(self.metadata.id, package)
 

--- a/backend.py
+++ b/backend.py
@@ -82,6 +82,30 @@ class SDist(Layout):
         return self.metadata.id
 
 
+class FlitSDist(SDist):
+    """
+    Customize the handling to generate a flit-compatible layout.
+
+    Puts README in the root, but the rest in the package.
+
+    >>> md = Message((('Name', 'foo'), ('Version', '1.0')))
+
+    >>> sf = FlitSDist(metadata=md)
+
+    >>> sf(types.SimpleNamespace(name='./bar.py'))
+    namespace(name='foo-1.0/foo/bar.py')
+
+    >>> sf(types.SimpleNamespace(name='./README.md'))
+    namespace(name='foo-1.0/README.md')
+    """
+
+    def prefix(self, name):
+        package = self.metadata['Name'].replace('.', '/')
+        if name.startswith('README.md'):
+            return pathlib.PurePath(self.metadata.id)
+        return pathlib.PurePath(self.metadata.id, package)
+
+
 class Wheel(Layout):
     """
     >>> wf = Wheel(metadata=dict(Name="foo"))

--- a/backend.py
+++ b/backend.py
@@ -66,10 +66,16 @@ def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
     return filename.name
 
 
+sdist_backends = dict(
+    flit=layouts.FlitSDist,
+    coherent=layouts.SDist,
+)
+
+
 def build_sdist(sdist_directory, config_settings=None):
     metadata = Message.discover()
     filename = pathlib.Path(sdist_directory) / f'{metadata.id}.tar.gz'
-    layout = layouts.FlitSDist(metadata)
+    layout = sdist_backends[os.environ.get('SDIST_BACKEND', 'coherent')](metadata)
     with tarfile.open(filename, 'w:gz') as tf:
         tf.add(pathlib.Path(), filter=layout)
         consume(itertools.starmap(tf.addfile, layout.add_files()))

--- a/backend.py
+++ b/backend.py
@@ -213,8 +213,9 @@ def build_sdist(sdist_directory, config_settings=None):
     metadata = Message.discover()
     filename = pathlib.Path(sdist_directory) / f'{metadata.id}.tar.gz'
     with tarfile.open(filename, 'w:gz') as tf:
-        tf.add(pathlib.Path(), filter=SDist(metadata))
+        tf.add(pathlib.Path(), filter=FlitSDist(metadata))
         tf.addfile(*make_sdist_metadata(metadata))
+        tf.addfile(*make_flit_project(metadata))
     return filename.name
 
 

--- a/backend.py
+++ b/backend.py
@@ -29,11 +29,10 @@ class Layout(abc.ABC):
         """
         self.metadata = metadata
 
-    @property
     @abc.abstractmethod
-    def root(self):
+    def prefix(self, name: str) -> str:
         """
-        Derives the root from the metadata.
+        Given the name, give its location.
         """
 
     def __call__(self, info):
@@ -42,13 +41,12 @@ class Layout(abc.ABC):
 
         Given an object like a tarfile.TarInfo object, determine if it
         should be included or filtered. Return None if the object should
-        be omitted. Otherwise, mutate the object to include self.root
-        as a prefix.
+        be omitted. Otherwise, relocate the object to self.prefix.
         """
         ignore_pattern = '|'.join(self.ignored)
         if info.name != '.' and re.match(ignore_pattern, info.name.removeprefix('./')):
             return
-        info.name = str(pathlib.PurePosixPath(self.root, info.name))
+        info.name = str(pathlib.PurePosixPath(self.prefix(info.name), info.name))
         return info
 
 
@@ -79,8 +77,7 @@ class SDist(Layout):
 
     ignored = ['dist$', r'(.*[/])?__pycache__$', r'(.*[/])?[.]']
 
-    @property
-    def root(self):
+    def prefix(self, name):
         return self.metadata.id
 
 
@@ -114,8 +111,7 @@ class Wheel(Layout):
         re.escape('pyproject.toml'),
     ]
 
-    @property
-    def root(self):
+    def prefix(self, name):
         return self.metadata['Name'].replace('.', '/')
 
 

--- a/backend.py
+++ b/backend.py
@@ -45,13 +45,10 @@ class Layout(abc.ABC):
         be omitted. Otherwise, mutate the object to include self.root
         as a prefix.
         """
-        if info.name == '.':
-            info.name = self.root
-            return info
         ignore_pattern = '|'.join(self.ignored)
-        if re.match(ignore_pattern, info.name.removeprefix('./')):
+        if info.name != '.' and re.match(ignore_pattern, info.name.removeprefix('./')):
             return
-        info.name = self.root + '/' + info.name.removeprefix('./')
+        info.name = str(pathlib.PurePosixPath(self.root, info.name))
         return info
 
 

--- a/backend.py
+++ b/backend.py
@@ -15,6 +15,7 @@ from collections.abc import Iterator
 from jaraco.functools import pass_none
 from wheel.wheelfile import WheelFile
 
+from . import flit
 from .metadata import Message
 
 
@@ -167,12 +168,20 @@ def wheel_walk(filter_: Wheel) -> Iterator[ZipInfo]:
         yield from filter(bool, map(filter_, children))
 
 
-def make_sdist_metadata(metadata: Message) -> tarfile.TarInfo:
-    info = tarfile.TarInfo(f'{metadata.id}/PKG-INFO')
-    file = io.BytesIO(metadata.render().encode('utf-8'))
+def make_tarinfo(filename, content):
+    info = tarfile.TarInfo(filename)
+    file = io.BytesIO(content.encode('utf-8'))
     info.size = len(file.getbuffer())
     info.mtime = time.time()
     return info, file
+
+
+def make_sdist_metadata(metadata: Message) -> tarfile.TarInfo:
+    return make_tarinfo(f'{metadata.id}/PKG-INFO', metadata.render())
+
+
+def make_flit_project(metadata: Message) -> tarfile.TarInfo:
+    return make_tarinfo(f'{metadata.id}/pyproject.toml', flit.render(metadata))
 
 
 def prepare_metadata(metadata_directory, config_settings=None):

--- a/backend.py
+++ b/backend.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-import abc
 import io
 import os
 import pathlib
 import posixpath
-import re
 import tarfile
 import textwrap
 import time
@@ -16,132 +14,8 @@ from jaraco.functools import pass_none
 from wheel.wheelfile import WheelFile
 
 from . import flit
+from . import layouts
 from .metadata import Message
-
-
-class Layout(abc.ABC):
-    """
-    Lay out tar- and zip-info objects for inclusion in different distributions.
-    """
-
-    def __init__(self, metadata: Message):
-        """
-        Initialize the filter with the root of the package ("coherent/build").
-        """
-        self.metadata = metadata
-
-    @abc.abstractmethod
-    def prefix(self, name: str) -> str:
-        """
-        Given the name, give its location.
-        """
-
-    def __call__(self, info):
-        """
-        Determine disposition for the info object.
-
-        Given an object like a tarfile.TarInfo object, determine if it
-        should be included or filtered. Return None if the object should
-        be omitted. Otherwise, relocate the object to self.prefix.
-        """
-        info.name = info.name.removeprefix('./')
-        ignore_pattern = '|'.join(self.ignored)
-        if info.name != '.' and re.match(ignore_pattern, info.name):
-            return
-        info.name = str(pathlib.PurePosixPath(self.prefix(info.name), info.name))
-        return info
-
-
-class SDist(Layout):
-    """
-    >>> sf = SDist(metadata=types.SimpleNamespace(id="foo"))
-
-    Ignores the .git directory
-    >>> sf(types.SimpleNamespace(name='./.git'))
-
-    Ignores __pycache__ directories
-    >>> sf(types.SimpleNamespace(name='./bar/__pycache__'))
-
-    Ignore paths starting with a dot
-    >>> sf(types.SimpleNamespace(name='./bar/.DS_Store'))
-
-    Ignore dist dirs
-    >>> sf(types.SimpleNamespace(name='./dist'))
-
-    Should not ignore nested dist dirs
-    >>> sf(types.SimpleNamespace(name='./bar/dist'))
-    namespace(name='foo/bar/dist')
-
-    Should not ignore paths that begin with 'dist'
-    >>> sf(types.SimpleNamespace(name='./distributions'))
-    namespace(name='foo/distributions')
-    """
-
-    ignored = ['dist$', r'(.*[/])?__pycache__$', r'(.*[/])?[.]']
-
-    def prefix(self, name):
-        return self.metadata.id
-
-
-class FlitSDist(SDist):
-    """
-    Customize the handling to generate a flit-compatible layout.
-
-    Puts README in the root, but the rest in the package.
-
-    >>> md = Message((('Name', 'foo'), ('Version', '1.0')))
-
-    >>> sf = FlitSDist(metadata=md)
-
-    >>> sf(types.SimpleNamespace(name='./bar.py'))
-    namespace(name='foo-1.0/foo/bar.py')
-
-    >>> sf(types.SimpleNamespace(name='./README.md'))
-    namespace(name='foo-1.0/README.md')
-    """
-
-    ignored = SDist.ignored + [re.escape('pyproject.toml')]
-
-    def prefix(self, name):
-        package = self.metadata['Name'].replace('.', '/')
-        root_pattern = '|'.join(Wheel.ignored)
-        if re.match(root_pattern, name):
-            return pathlib.PurePath(self.metadata.id)
-        return pathlib.PurePath(self.metadata.id, package)
-
-
-class Wheel(Layout):
-    """
-    >>> wf = Wheel(metadata=dict(Name="foo"))
-
-    Ignore all the things SDist does (coherent-oss/coherent.build#33)
-    >>> wf(types.SimpleNamespace(name='./.git'))
-    >>> wf(types.SimpleNamespace(name='./bar/__pycache__'))
-    >>> wf(types.SimpleNamespace(name='./bar/.DS_Store'))
-    >>> wf(types.SimpleNamespace(name='./dist'))
-    >>> wf(types.SimpleNamespace(name='./bar/dist'))
-    namespace(name='foo/bar/dist')
-    >>> wf(types.SimpleNamespace(name='./distributions'))
-    namespace(name='foo/distributions')
-
-    Additionally, filters out non-project files:
-    >>> wf(types.SimpleNamespace(name='./README.rst'))
-    >>> wf(types.SimpleNamespace(name='./docs'))
-    >>> wf(types.SimpleNamespace(name='./(meta)'))
-    >>> wf(types.SimpleNamespace(name='./pyproject.toml'))
-    """
-
-    ignored = SDist.ignored + [
-        'docs',
-        'tests',
-        r'README.*',
-        'PKG-INFO',
-        re.escape('(meta)'),
-        re.escape('pyproject.toml'),
-    ]
-
-    def prefix(self, name):
-        return self.metadata['Name'].replace('.', '/')
 
 
 class ZipInfo(types.SimpleNamespace):
@@ -154,7 +28,7 @@ class ZipInfo(types.SimpleNamespace):
         super().__init__(path=path, name=zip_name)
 
 
-def wheel_walk(filter_: Wheel) -> Iterator[ZipInfo]:
+def wheel_walk(filter_: layouts.Wheel) -> Iterator[ZipInfo]:
     """
     Walk the current directory, applying and honoring the filter for traversal.
     """
@@ -202,7 +76,7 @@ def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
     )
     filename = pathlib.Path(wheel_directory) / f'{metadata.id}-py3-none-any.whl'
     with WheelFile(filename, 'w') as zf:
-        for info in wheel_walk(Wheel(metadata)):
+        for info in wheel_walk(layouts.Wheel(metadata)):
             zf.write(info.path, arcname=info.name)
         for name, contents in metadata.render_wheel():
             zf.writestr(f'{metadata.id}.dist-info/{name}', contents)
@@ -213,7 +87,7 @@ def build_sdist(sdist_directory, config_settings=None):
     metadata = Message.discover()
     filename = pathlib.Path(sdist_directory) / f'{metadata.id}.tar.gz'
     with tarfile.open(filename, 'w:gz') as tf:
-        tf.add(pathlib.Path(), filter=FlitSDist(metadata))
+        tf.add(pathlib.Path(), filter=layouts.FlitSDist(metadata))
         tf.addfile(*make_sdist_metadata(metadata))
         tf.addfile(*make_flit_project(metadata))
     return filename.name

--- a/flit.py
+++ b/flit.py
@@ -1,19 +1,13 @@
-import sys
-
 import tomlkit
 
 from . import metadata
 
 
-def write():
-    md = metadata.Message.discover()
+def render(metadata: metadata.Message):
     system = {
         'build-system': {
             'requires': ['flit-core >=3.11, <4'],
             'build-backend': 'flit_core.buildapi',
         }
     }
-    tomlkit.dump(system | md.render_toml(), sys.stdout)
-
-
-__name__ == '__main__' and write()
+    return tomlkit.dumps(system | metadata.render_toml())

--- a/flit.py
+++ b/flit.py
@@ -7,14 +7,13 @@ from . import metadata
 
 def write():
     md = metadata.Message.discover()
-    doc = md.render_toml()
-    doc.update({
+    system = {
         'build-system': {
             'requires': ['flit-core >=3.11, <4'],
             'build-backend': 'flit_core.buildapi',
         }
-    })
-    tomlkit.dump(doc, sys.stdout)
+    }
+    tomlkit.dump(system | md.render_toml(), sys.stdout)
 
 
 __name__ == '__main__' and write()

--- a/flit.py
+++ b/flit.py
@@ -1,0 +1,20 @@
+import sys
+
+import tomlkit
+
+from . import metadata
+
+
+def write():
+    md = metadata.Message.discover()
+    doc = md.render_toml()
+    doc.update({
+        'build-system': {
+            'requires': ['flit-core >=3.11, <4'],
+            'build-backend': 'flit_core.buildapi',
+        }
+    })
+    tomlkit.dump(doc, sys.stdout)
+
+
+__name__ == '__main__' and write()

--- a/layouts.py
+++ b/layouts.py
@@ -1,0 +1,133 @@
+import abc
+import pathlib
+import re
+
+from .metadata import Message
+
+
+class Layout(abc.ABC):
+    """
+    Lay out tar- and zip-info objects for inclusion in different distributions.
+    """
+
+    def __init__(self, metadata: Message):
+        """
+        Initialize the filter with the root of the package ("coherent/build").
+        """
+        self.metadata = metadata
+
+    @abc.abstractmethod
+    def prefix(self, name: str) -> str:
+        """
+        Given the name, give its location.
+        """
+
+    def __call__(self, info):
+        """
+        Determine disposition for the info object.
+
+        Given an object like a tarfile.TarInfo object, determine if it
+        should be included or filtered. Return None if the object should
+        be omitted. Otherwise, relocate the object to self.prefix.
+        """
+        info.name = info.name.removeprefix('./')
+        ignore_pattern = '|'.join(self.ignored)
+        if info.name != '.' and re.match(ignore_pattern, info.name):
+            return
+        info.name = str(pathlib.PurePosixPath(self.prefix(info.name), info.name))
+        return info
+
+
+class SDist(Layout):
+    """
+    >>> import types
+    >>> sf = SDist(metadata=types.SimpleNamespace(id="foo"))
+
+    Ignores the .git directory
+    >>> sf(types.SimpleNamespace(name='./.git'))
+
+    Ignores __pycache__ directories
+    >>> sf(types.SimpleNamespace(name='./bar/__pycache__'))
+
+    Ignore paths starting with a dot
+    >>> sf(types.SimpleNamespace(name='./bar/.DS_Store'))
+
+    Ignore dist dirs
+    >>> sf(types.SimpleNamespace(name='./dist'))
+
+    Should not ignore nested dist dirs
+    >>> sf(types.SimpleNamespace(name='./bar/dist'))
+    namespace(name='foo/bar/dist')
+
+    Should not ignore paths that begin with 'dist'
+    >>> sf(types.SimpleNamespace(name='./distributions'))
+    namespace(name='foo/distributions')
+    """
+
+    ignored = ['dist$', r'(.*[/])?__pycache__$', r'(.*[/])?[.]']
+
+    def prefix(self, name):
+        return self.metadata.id
+
+
+class FlitSDist(SDist):
+    """
+    Customize the handling to generate a flit-compatible layout.
+
+    Puts README in the root, but the rest in the package.
+
+    >>> import types
+    >>> md = Message((('Name', 'foo'), ('Version', '1.0')))
+
+    >>> sf = FlitSDist(metadata=md)
+
+    >>> sf(types.SimpleNamespace(name='./bar.py'))
+    namespace(name='foo-1.0/foo/bar.py')
+
+    >>> sf(types.SimpleNamespace(name='./README.md'))
+    namespace(name='foo-1.0/README.md')
+    """
+
+    ignored = SDist.ignored + [re.escape('pyproject.toml')]
+
+    def prefix(self, name):
+        package = self.metadata['Name'].replace('.', '/')
+        root_pattern = '|'.join(Wheel.ignored)
+        if re.match(root_pattern, name):
+            return pathlib.PurePath(self.metadata.id)
+        return pathlib.PurePath(self.metadata.id, package)
+
+
+class Wheel(Layout):
+    """
+    >>> import types
+    >>> wf = Wheel(metadata=dict(Name="foo"))
+
+    Ignore all the things SDist does (coherent-oss/coherent.build#33)
+    >>> wf(types.SimpleNamespace(name='./.git'))
+    >>> wf(types.SimpleNamespace(name='./bar/__pycache__'))
+    >>> wf(types.SimpleNamespace(name='./bar/.DS_Store'))
+    >>> wf(types.SimpleNamespace(name='./dist'))
+    >>> wf(types.SimpleNamespace(name='./bar/dist'))
+    namespace(name='foo/bar/dist')
+    >>> wf(types.SimpleNamespace(name='./distributions'))
+    namespace(name='foo/distributions')
+
+    Additionally, filters out non-project files:
+    >>> wf(types.SimpleNamespace(name='./README.rst'))
+    >>> wf(types.SimpleNamespace(name='./docs'))
+    >>> wf(types.SimpleNamespace(name='./(meta)'))
+    >>> wf(types.SimpleNamespace(name='./pyproject.toml'))
+    """
+
+    ignored = SDist.ignored + [
+        'docs',
+        'tests',
+        r'README.*',
+        'PKG-INFO',
+        re.escape('(meta)'),
+        re.escape('pyproject.toml'),
+    ]
+
+    def prefix(self, name):
+        return self.metadata['Name'].replace('.', '/')


### PR DESCRIPTION
- **Added an initial method to render the metadata as pyproject toml.**
- **Refined metadata.Message.render_toml and added flit module to write out the file.**
- **Render the build system at the top.**
- **Refactored the layout objects.**
- **Remove special handling for . and rely on pathlib for path joining.**
- **Replace 'root' with 'prefix', which may vary by path.**
- **Remove any ./ prefix early.**
- **Add FlitSDist with support for conditionally relocating files.**
- **Fix handling in FlitSDist to ignore pyproject.toml and only move project files to the package directory.**
- **Re-wrote flit module with a render method.**
- **Add 'make_flit_project' and extract commonality with make_dist_metadata.**
- **Replace coherent sdist with Flit sdist.**
- **Move layouts to their own module.**
- **Move 'add_files' functionality into SDist classes.**

Maybe closes #32
