### PR TITLE
Make license declarations explicit

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,8 @@ __requires__ = [
     'importlib_resources; python_version < "3.12"',
 ]
 
+__license__ = 'Apache-2.0'
+
 # honor PYTHONSAFEPATH (coherent-oss/system#21)
 import jaraco.compat.py310.safe_path  # noqa: F401
 

--- a/discovery.py
+++ b/discovery.py
@@ -201,10 +201,10 @@ def declared_license():
 
     Returns None if no ``__license__`` is declared.
 
-    >>> declared_license()
     >>> monkeypatch = getfixture('monkeypatch')
     >>> tmp_path = getfixture('tmp_path')
     >>> monkeypatch.chdir(tmp_path)
+    >>> declared_license()
     >>> _ = (tmp_path / '__init__.py').write_text('__license__ = "MIT"\\n')
     >>> declared_license()
     'MIT'

--- a/flit.py
+++ b/flit.py
@@ -113,4 +113,5 @@ class SDist(layouts.SDist):
         yield from super().gen_files()
         yield 'pyproject.toml', render(self.metadata)
         yield self.metadata.readme_filename, self.metadata['Description']
-        yield 'LICENSE', coherent.licensed.resolve(self.metadata['License-Expression'])
+        if license := self.metadata['License-Expression']:
+            yield 'LICENSE', coherent.licensed.resolve(license)

--- a/metadata.py
+++ b/metadata.py
@@ -112,7 +112,8 @@ class Message(email.message.Message):
         yield from discovery.best_description()
         for classifier in discovery.generate_classifiers():
             yield 'Classifier', classifier
-        yield 'License-Expression', discovery.declared_license() or 'Apache-2.0'
+        if license := discovery.declared_license():
+            yield 'License-Expression', license
 
     @classmethod
     @suppress(MetadataNotFound)
@@ -153,8 +154,9 @@ class Message(email.message.Message):
             "dependencies": self.get_all("Requires-Dist") or [],
             "classifiers": self.get_all("Classifier") or [],
             'urls': self.urls,
-            'license': self['License-Expression'],
         }
+        if license := self['License-Expression']:
+            project['license'] = license
 
         return project
 


### PR DESCRIPTION
Closes #67 (build-system portion).

Previously the build applied an `Apache-2.0` license by default when no license was declared. Per #67, license selection should be a positive signal with no default — a package without a declared license simply has no license indicated in the metadata.

## Changes
- `metadata.py`: omit `License-Expression` from METADATA and `license` from the generated `pyproject.toml` when no `__license__` is declared.
- `flit.py`: only inject the `LICENSE` file into the sdist when a license is declared.
- `__init__.py`: declare `__license__ = 'Apache-2.0'` for coherent.build itself (per #67's directive to make coherent.* projects explicit).

The remaining parts of #67 — licensing guidance in the coherent-oss/system README and Apache-2.0 declarations in the other coherent.* projects — are handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)